### PR TITLE
Fix code of pair parser combinator to pass the tests

### DIFF
--- a/content/parser-combinators/index.md
+++ b/content/parser-combinators/index.md
@@ -439,7 +439,7 @@ where
     move |input| match parser1(input) {
         Ok((next_input, result1)) => match parser2(next_input) {
             Ok((final_input, result2)) => Ok((final_input, (result1, result2))),
-            Err(err) => Err(err),
+            Err(_err) => Err(input),
         },
         Err(err) => Err(err),
     }
@@ -650,7 +650,7 @@ where
     move |input| match parser1.parse(input) {
         Ok((next_input, result1)) => match parser2.parse(next_input) {
             Ok((final_input, result2)) => Ok((final_input, (result1, result2))),
-            Err(err) => Err(err),
+            Err(_err) => Err(input),
         },
         Err(err) => Err(err),
     }
@@ -673,6 +673,7 @@ where
         parser1.parse(input).and_then(|(next_input, result1)| {
             parser2.parse(next_input)
                 .map(|(last_input, result2)| (last_input, (result1, result2)))
+                .map_err(|_err| (input))
         })
     }
 }


### PR DESCRIPTION
There is a bug in pair parser combinator that causes introduced tests to fail.
The problem is that when the first parser successfully parses the input
and the second doesn't, the combinator returns the error representing
the input of the second parser not the input of the whole pair
combinator.